### PR TITLE
Fix HA 2026.x compatibility: options flow and logger name

### DIFF
--- a/custom_components/harvia_sauna/__init__.py
+++ b/custom_components/harvia_sauna/__init__.py
@@ -606,7 +606,8 @@ class HarviaSauna:
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Setup de Harvia Sauna integratie."""
-    boto3.set_stream_logger('custom_components.harvia_sauna')
+    # boto3 stream logger removed — it adds a StreamHandler that
+    # bypasses HA log level filtering and floods the log output
 
     return True
 

--- a/custom_components/harvia_sauna/__init__.py
+++ b/custom_components/harvia_sauna/__init__.py
@@ -26,7 +26,7 @@ from homeassistant.const import STATE_ON, STATE_OFF, CONF_USERNAME, CONF_PASSWOR
 from pycognito import Cognito
 import boto3
 
-_LOGGER = logging.getLogger('custom_component.harvia_sauna')
+_LOGGER = logging.getLogger(__name__)
 ENTITY_TYPES = [ 'switch', 'climate',  'binary_sensor', 'sensor', 'number']
 
 class HarviaDevice:
@@ -606,7 +606,7 @@ class HarviaSauna:
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Setup de Harvia Sauna integratie."""
-    boto3.set_stream_logger('custom_component.harvia_sauna')
+    boto3.set_stream_logger('custom_components.harvia_sauna')
 
     return True
 

--- a/custom_components/harvia_sauna/api.py
+++ b/custom_components/harvia_sauna/api.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .constants import DOMAIN, REGION
 
-_LOGGER = logging.getLogger('custom_component.harvia_sauna')
+_LOGGER = logging.getLogger(__name__)
 
 class HarviaSaunaAPI:
     def __init__(self, username, password, hass):

--- a/custom_components/harvia_sauna/config_flow.py
+++ b/custom_components/harvia_sauna/config_flow.py
@@ -37,14 +37,12 @@ class HarviaSaunaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }),
             errors=errors,
         )
+    @staticmethod
+    @callback
     def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> config_entries.OptionsFlow:
-        return HarviaSaunaOptionsFlowHandler(config_entry)
+        return HarviaSaunaOptionsFlowHandler()
 
 class HarviaSaunaOptionsFlowHandler(config_entries.OptionsFlow):
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
-
     async def async_step_init(self, user_input=None):
         """Beheer de opties."""
         errors = {}

--- a/custom_components/harvia_sauna/constants.py
+++ b/custom_components/harvia_sauna/constants.py
@@ -1,5 +1,5 @@
 import logging
-_LOGGER = logging.getLogger('custom_component.harvia_sauna')
+_LOGGER = logging.getLogger(__name__)
 DOMAIN = "harvia_sauna"
 STORAGE_KEY = "harvia_sauna"
 STORAGE_VERSION = 1


### PR DESCRIPTION
## Summary
TLDR; control debug level in ... settings, reduce error/warning flood in logs.

- **Fix OptionsFlowHandler crash on HA 2026.3+**: `config_entry` is now a read-only property on `OptionsFlow`, so the `__init__` that sets `self.config_entry` raises `AttributeError: property 'config_entry' of 'HarviaSaunaOptionsFlowHandler' object has no setter`. Removed the `__init__` (HA sets it automatically) and added `@staticmethod @callback` to `async_get_options_flow`.
- **Fix debug log flooding**: Logger name was `custom_component.harvia_sauna` (singular), which doesn't match HA's `custom_components.*` hierarchy. This caused all debug-level log messages to bypass HA's log level filtering and flood the log output. Changed to `__name__` which resolves correctly.
- **Remove `boto3.set_stream_logger()`**: This call added a separate `StreamHandler` directly to the Python logger, bypassing HA's log level configuration entirely. Even with the correct logger name, this handler would dump all debug messages to stderr. Removing it lets HA's logging system control the level properly.

## Tested on
- Home Assistant 2026.3.3, HAOS 17.1, Python 3.14.2 (aarch64)
- Harvia Xenio WiFi (HARVIA-WIFI-XENIO, serial 2108007326)

## Test results
- [x] Options flow no longer crashes with `AttributeError` on HA 2026.3+
- [x] Debug logs no longer shown at default log level (0 DEBUG lines vs ~3400/5000 before)
- [x] Debug logging toggle in UI (Settings > Devices & Services > Harvia Sauna > Enable debug logging) works correctly: debug lines appear when enabled, stop when disabled
- [x] No restart needed for debug toggle (takes effect immediately)
- [x] Integration functions normally: websocket connections to Harvia cloud, device updates, sensor/switch entities all working
- [x] `configuration.yaml` logger overrides not needed — HA's default level filtering works correctly with fixed logger names

Generated with [Claude Code](https://claude.com/claude-code)